### PR TITLE
Returns empty array if Blockchain says there aren't any unspent transactions

### DIFF
--- a/CoreBitcoin/BTCEncryptedMessage.m
+++ b/CoreBitcoin/BTCEncryptedMessage.m
@@ -40,7 +40,7 @@ static uint32_t BTCEMFullTargetForCompactTarget(uint8_t compactTarget);
     self.address = BTCHash160(recipientPubKey);
     self.addressLength = MIN(self.address.length * 8, self.addressLength);
     
-    self.timestamp = (uint32_t)[[NSData data] timeIntervalSince1970];
+    self.timestamp = (uint32_t)[[NSDate date] timeIntervalSince1970];
     
     // Transform seed into a unique per-message seed.
     // TODO: perform raw SHA computation to be able to erase digests from memory.


### PR DESCRIPTION
Blockchain just outputs "No free outputs to spend" when the address hasn't received any transactions. JSON parsing fails, and so it falls through, and returns nil. It really should otherwise return an empty array, which I've set it up to do. In the context of this error, code 3840 means a JSON parsing error, which means Blockchain is returning "No free outputs to spend". As for errorOut, because we know that an error didn't _really_ happen, it's just the way Blockchain communicates an empty list, we errorOut will remain nil.
