### PR TITLE
Always use OpenSSL 1.0.1

### DIFF
--- a/CoreBitcoin.podspec
+++ b/CoreBitcoin.podspec
@@ -19,5 +19,5 @@ Pod::Spec.new do |s|
   s.exclude_files = 'CoreBitcoin/**/*+Tests.{h,m}'
   s.requires_arc = true
   s.framework    = 'Foundation'
-  s.dependency 'OpenSSL', '~> 1.0.1'
+  s.dependency 'OpenSSL', '1.0.1'
 end


### PR DESCRIPTION
It seems OpenSSL doesn't adhere perfectly to semver. Version 1.0.108 seems to have different files than 1.0.1, which causes issues when CoreBitcoin imports OpenSSL files. 

Because OpenSSL doesn't properly semver, `~>` shouldn't be used; we should specify the version number exactly.
