### PR TITLE
requestForUnspentOutputsWithAddresses fix

### DIFF
--- a/CoreBitcoin/BTCBlockchainInfo.m
+++ b/CoreBitcoin/BTCBlockchainInfo.m
@@ -10,7 +10,7 @@
 {
     if (addresses.count == 0) return nil;
     
-    NSString* urlstring = [NSString stringWithFormat:@"https://blockchain.info/unspent?active=%@", [[addresses valueForKey:@"base58String"] componentsJoinedByString:@"|"]];
+    NSString* urlstring = [NSString stringWithFormat:@"https://blockchain.info/unspent?active=%@", [[addresses valueForKey:@"base58String"] componentsJoinedByString:@"%7C"]];
     NSMutableURLRequest* request = [[NSMutableURLRequest alloc] initWithURL:[NSURL URLWithString:urlstring]];
     request.HTTPMethod = @"GET";
     return request;


### PR DESCRIPTION
I was unable to fetch unspent outputs for multiple addresses with the latest xCode6-Beta3 because of the pipe char "|". I replaced it by the encoded form: "%7C" and voilà! 

Btw, thanks for this great lib! Can't wait to see the next features.
