### PR TITLE
Use xcode command line tools to get developer path and SKD versions

### DIFF
--- a/update_openssl.sh
+++ b/update_openssl.sh
@@ -8,10 +8,10 @@
 
 OPENSSL_VERSION="1.0.1e"
 
-DEVELOPER="/Applications/Xcode.app/Contents/Developer"
+DEVELOPER=`xcode-select -print-path`
 
-IOS_SDK_VERSION="8.1"
-OSX_SDK_VERSION="10.9"
+IOS_SDK_VERSION=`xcrun -sdk iphoneos --show-sdk-version`
+OSX_SDK_VERSION=`xcrun -sdk macosx --show-sdk-version`
 
 WORKDIR=${PWD}
 


### PR DESCRIPTION
The OpenSSL build din't work for me because I had the newest SDK versions for iOS (8.2) and MacOSX (10.10). This fixes it in a general way that will work in the future as well.