### PR TITLE
Convert comments in SignatureHashType and Opcode to be appledoc compatible

### DIFF
--- a/CoreBitcoin/BTCOpcode.h
+++ b/CoreBitcoin/BTCOpcode.h
@@ -1,35 +1,37 @@
-// CoreBitcoin by Oleg Andreev <oleganza@gmail.com>, WTFPL.
+/// CoreBitcoin by Oleg Andreev <oleganza@gmail.com>, WTFPL.
 
 #import <Foundation/Foundation.h>
 
-// See below for declarations of:
-// NSString* BTCNameForOpcode(BTCOpcode opcode);
-// BTCOpcode BTCOpcodeForName(NSString* opcodeName);
-// BTCOpcode BTCOpcodeForSmallInteger(NSInteger smallInteger);
-// NSInteger BTCSmallIntegerFromOpcode(BTCOpcode opcode);
+/**
+ * See below for declarations of:
+ * NSString* BTCNameForOpcode(BTCOpcode opcode);
+ * BTCOpcode BTCOpcodeForName(NSString* opcodeName);
+ * BTCOpcode BTCOpcodeForSmallInteger(NSInteger smallInteger);
+ * NSInteger BTCSmallIntegerFromOpcode(BTCOpcode opcode);
+ */
 
 
-// Script consists of opcodes ("operation codes") and raw binary data.
-// Opcodes define how the data is added, removed and modified on the stack.
+/// Script consists of opcodes ("operation codes") and raw binary data.
+/// Opcodes define how the data is added, removed and modified on the stack.
 typedef NS_ENUM(unsigned char, BTCOpcode)
 {
-    // 1. Operators pushing data on stack.
+    /// 1. Operators pushing data on stack.
     
-    // Push 1 byte 0x00 on the stack
+    /// Push 1 byte 0x00 on the stack
     OP_0 = 0x00,
     OP_FALSE = OP_0,
     
-    // Any opcode with value < PUSHDATA1 is a length of the string to be pushed on the stack.
-    // So opcode 0x01 is followed by 1 byte of data, 0x09 by 9 bytes and so on up to 0x4b (75 bytes)
+    /// Any opcode with value < PUSHDATA1 is a length of the string to be pushed on the stack.
+    /// So opcode 0x01 is followed by 1 byte of data, 0x09 by 9 bytes and so on up to 0x4b (75 bytes)
     
-    // PUSHDATA<N> opcode is followed by N-byte length of the string that follows.
-    OP_PUSHDATA1 = 0x4c, // followed by a 1-byte length of the string to push (allows pushing 0..255 bytes).
-    OP_PUSHDATA2 = 0x4d, // followed by a 2-byte length of the string to push (allows pushing 0..65535 bytes).
-    OP_PUSHDATA4 = 0x4e, // followed by a 4-byte length of the string to push (allows pushing 0..4294967295 bytes).
-    OP_1NEGATE   = 0x4f, // pushes -1 number on the stack
-    OP_RESERVED  = 0x50, // Not assigned. If executed, transaction is invalid.
+    /// PUSHDATA<N> opcode is followed by N-byte length of the string that follows.
+    OP_PUSHDATA1 = 0x4c, /// followed by a 1-byte length of the string to push (allows pushing 0..255 bytes).
+    OP_PUSHDATA2 = 0x4d, /// followed by a 2-byte length of the string to push (allows pushing 0..65535 bytes).
+    OP_PUSHDATA4 = 0x4e, /// followed by a 4-byte length of the string to push (allows pushing 0..4294967295 bytes).
+    OP_1NEGATE   = 0x4f, /// pushes -1 number on the stack
+    OP_RESERVED  = 0x50, /// Not assigned. If executed, transaction is invalid.
     
-    // OP_<N> pushes number <N> on the stack
+    /// OP_<N> pushes number <N> on the stack
     OP_1  = 0x51,
     OP_TRUE=OP_1,
     OP_2  = 0x52,
@@ -48,27 +50,27 @@ typedef NS_ENUM(unsigned char, BTCOpcode)
     OP_15 = 0x5f,
     OP_16 = 0x60,
     
-    // 2. Control flow operators
+    /// 2. Control flow operators
     
-    OP_NOP      = 0x61, // Does nothing
-    OP_VER      = 0x62, // Not assigned. If executed, transaction is invalid.
+    OP_NOP      = 0x61, /// Does nothing
+    OP_VER      = 0x62, /// Not assigned. If executed, transaction is invalid.
     
-    // BitcoinQT executes all operators from OP_IF to OP_ENDIF even inside "non-executed" branch (to keep track of nesting).
-    // Since OP_VERIF and OP_VERNOTIF are not assigned, even inside a non-executed branch they will fall in "default:" switch case
-    // and cause the script to fail. Some other ops like OP_VER can be present inside non-executed branch because they'll be skipped.
-    OP_IF       = 0x63, // If the top stack value is not 0, the statements are executed. The top stack value is removed.
-    OP_NOTIF    = 0x64, // If the top stack value is 0, the statements are executed. The top stack value is removed.
-    OP_VERIF    = 0x65, // Not assigned. Script is invalid with that opcode (even if inside non-executed branch).
-    OP_VERNOTIF = 0x66, // Not assigned. Script is invalid with that opcode (even if inside non-executed branch).
-    OP_ELSE     = 0x67, // Executes code if the previous OP_IF or OP_NOTIF was not executed.
-    OP_ENDIF    = 0x68, // Finishes if/else block
+    /// BitcoinQT executes all operators from OP_IF to OP_ENDIF even inside "non-executed" branch (to keep track of nesting).
+    /// Since OP_VERIF and OP_VERNOTIF are not assigned, even inside a non-executed branch they will fall in "default:" switch case
+    /// and cause the script to fail. Some other ops like OP_VER can be present inside non-executed branch because they'll be skipped.
+    OP_IF       = 0x63, /// If the top stack value is not 0, the statements are executed. The top stack value is removed.
+    OP_NOTIF    = 0x64, /// If the top stack value is 0, the statements are executed. The top stack value is removed.
+    OP_VERIF    = 0x65, /// Not assigned. Script is invalid with that opcode (even if inside non-executed branch).
+    OP_VERNOTIF = 0x66, /// Not assigned. Script is invalid with that opcode (even if inside non-executed branch).
+    OP_ELSE     = 0x67, /// Executes code if the previous OP_IF or OP_NOTIF was not executed.
+    OP_ENDIF    = 0x68, /// Finishes if/else block
     
-    OP_VERIFY   = 0x69, // Removes item from the stack if it's not 0x00 or 0x80 (negative zero). Otherwise, marks script as invalid.
-    OP_RETURN   = 0x6a, // Marks transaction as invalid.
+    OP_VERIFY   = 0x69, /// Removes item from the stack if it's not 0x00 or 0x80 (negative zero). Otherwise, marks script as invalid.
+    OP_RETURN   = 0x6a, /// Marks transaction as invalid.
     
-    // Stack ops
-    OP_TOALTSTACK   = 0x6b, // Moves item from the stack to altstack
-    OP_FROMALTSTACK = 0x6c, // Moves item from the altstack to stack
+    /// Stack ops
+    OP_TOALTSTACK   = 0x6b, /// Moves item from the stack to altstack
+    OP_FROMALTSTACK = 0x6c, /// Moves item from the altstack to stack
     OP_2DROP = 0x6d,
     OP_2DUP  = 0x6e,
     OP_3DUP  = 0x6f,
@@ -87,42 +89,42 @@ typedef NS_ENUM(unsigned char, BTCOpcode)
     OP_SWAP  = 0x7c,
     OP_TUCK  = 0x7d,
     
-    // Splice ops
-    OP_CAT    = 0x7e, // Disabled opcode. If executed, transaction is invalid.
-    OP_SUBSTR = 0x7f, // Disabled opcode. If executed, transaction is invalid.
-    OP_LEFT   = 0x80, // Disabled opcode. If executed, transaction is invalid.
-    OP_RIGHT  = 0x81, // Disabled opcode. If executed, transaction is invalid.
+    /// Splice ops
+    OP_CAT    = 0x7e, /// Disabled opcode. If executed, transaction is invalid.
+    OP_SUBSTR = 0x7f, /// Disabled opcode. If executed, transaction is invalid.
+    OP_LEFT   = 0x80, /// Disabled opcode. If executed, transaction is invalid.
+    OP_RIGHT  = 0x81, /// Disabled opcode. If executed, transaction is invalid.
     OP_SIZE   = 0x82,
     
-    // Bit logic
-    OP_INVERT = 0x83, // Disabled opcode. If executed, transaction is invalid.
-    OP_AND    = 0x84, // Disabled opcode. If executed, transaction is invalid.
-    OP_OR     = 0x85, // Disabled opcode. If executed, transaction is invalid.
-    OP_XOR    = 0x86, // Disabled opcode. If executed, transaction is invalid.
+    /// Bit logic
+    OP_INVERT = 0x83, /// Disabled opcode. If executed, transaction is invalid.
+    OP_AND    = 0x84, /// Disabled opcode. If executed, transaction is invalid.
+    OP_OR     = 0x85, /// Disabled opcode. If executed, transaction is invalid.
+    OP_XOR    = 0x86, /// Disabled opcode. If executed, transaction is invalid.
     
-    OP_EQUAL = 0x87,        // Last two items are removed from the stack and compared. Result (true or false) is pushed to the stack.
-    OP_EQUALVERIFY = 0x88,  // Same as OP_EQUAL, but removes the result from the stack if it's true or marks script as invalid.
+    OP_EQUAL = 0x87,        /// Last two items are removed from the stack and compared. Result (true or false) is pushed to the stack.
+    OP_EQUALVERIFY = 0x88,  /// Same as OP_EQUAL, but removes the result from the stack if it's true or marks script as invalid.
     
-    OP_RESERVED1 = 0x89, // Disabled opcode. If executed, transaction is invalid.
-    OP_RESERVED2 = 0x8a, // Disabled opcode. If executed, transaction is invalid.
+    OP_RESERVED1 = 0x89, /// Disabled opcode. If executed, transaction is invalid.
+    OP_RESERVED2 = 0x8a, /// Disabled opcode. If executed, transaction is invalid.
     
-    // Numeric
-    OP_1ADD      = 0x8b,  // adds 1 to last item, pops it from stack and pushes result.
-    OP_1SUB      = 0x8c,  // substracts 1 to last item, pops it from stack and pushes result.
-    OP_2MUL      = 0x8d,  // Disabled opcode. If executed, transaction is invalid.
-    OP_2DIV      = 0x8e,  // Disabled opcode. If executed, transaction is invalid.
-    OP_NEGATE    = 0x8f,  // negates the number, pops it from stack and pushes result.
-    OP_ABS       = 0x90,  // replaces number with its absolute value
-    OP_NOT       = 0x91,  // replaces number with True if it's zero, False otherwise.
-    OP_0NOTEQUAL = 0x92,  // replaces number with True if it's not zero, False otherwise.
+    /// Numeric
+    OP_1ADD      = 0x8b,  /// adds 1 to last item, pops it from stack and pushes result.
+    OP_1SUB      = 0x8c,  /// substracts 1 to last item, pops it from stack and pushes result.
+    OP_2MUL      = 0x8d,  /// Disabled opcode. If executed, transaction is invalid.
+    OP_2DIV      = 0x8e,  /// Disabled opcode. If executed, transaction is invalid.
+    OP_NEGATE    = 0x8f,  /// negates the number, pops it from stack and pushes result.
+    OP_ABS       = 0x90,  /// replaces number with its absolute value
+    OP_NOT       = 0x91,  /// replaces number with True if it's zero, False otherwise.
+    OP_0NOTEQUAL = 0x92,  /// replaces number with True if it's not zero, False otherwise.
     
-    OP_ADD    = 0x93,  // (x y -- x+y)
-    OP_SUB    = 0x94,  // (x y -- x-y)
-    OP_MUL    = 0x95,  // Disabled opcode. If executed, transaction is invalid.
-    OP_DIV    = 0x96,  // Disabled opcode. If executed, transaction is invalid.
-    OP_MOD    = 0x97,  // Disabled opcode. If executed, transaction is invalid.
-    OP_LSHIFT = 0x98,  // Disabled opcode. If executed, transaction is invalid.
-    OP_RSHIFT = 0x99,  // Disabled opcode. If executed, transaction is invalid.
+    OP_ADD    = 0x93,  /// (x y -- x+y)
+    OP_SUB    = 0x94,  /// (x y -- x-y)
+    OP_MUL    = 0x95,  /// Disabled opcode. If executed, transaction is invalid.
+    OP_DIV    = 0x96,  /// Disabled opcode. If executed, transaction is invalid.
+    OP_MOD    = 0x97,  /// Disabled opcode. If executed, transaction is invalid.
+    OP_LSHIFT = 0x98,  /// Disabled opcode. If executed, transaction is invalid.
+    OP_RSHIFT = 0x99,  /// Disabled opcode. If executed, transaction is invalid.
     
     OP_BOOLAND            = 0x9a,
     OP_BOOLOR             = 0x9b,
@@ -138,19 +140,19 @@ typedef NS_ENUM(unsigned char, BTCOpcode)
     
     OP_WITHIN = 0xa5,
     
-    // Crypto
+    /// Crypto
     OP_RIPEMD160      = 0xa6,
     OP_SHA1           = 0xa7,
     OP_SHA256         = 0xa8,
     OP_HASH160        = 0xa9,
     OP_HASH256        = 0xaa,
-    OP_CODESEPARATOR  = 0xab, // This opcode is rarely used because it's useless, but we need to support it anyway.
+    OP_CODESEPARATOR  = 0xab, /// This opcode is rarely used because it's useless, but we need to support it anyway.
     OP_CHECKSIG       = 0xac,
     OP_CHECKSIGVERIFY = 0xad,
     OP_CHECKMULTISIG  = 0xae,
     OP_CHECKMULTISIGVERIFY = 0xaf,
     
-    // Expansion
+    /// Expansion
     OP_NOP1  = 0xb0,
     OP_NOP2  = 0xb1,
     OP_NOP3  = 0xb2,
@@ -166,18 +168,18 @@ typedef NS_ENUM(unsigned char, BTCOpcode)
 };
 
 
-// Returns name for opcode or @"OP_UNKNOWN" for unknown opcode.
+/// Returns name for opcode or @"OP_UNKNOWN" for unknown opcode.
 NSString* BTCNameForOpcode(BTCOpcode opcode);
 
-// Returns opcode integer for a given name. Returns OP_INVALIDOPCODE for unknown name.
+/// Returns opcode integer for a given name. Returns OP_INVALIDOPCODE for unknown name.
 BTCOpcode BTCOpcodeForName(NSString* opcodeName);
 
-// Returns OP_1NEGATE, OP_0 .. OP_16 for ints from -1 to 16.
-// Returns OP_INVALIDOPCODE for other ints.
+/// Returns OP_1NEGATE, OP_0 .. OP_16 for ints from -1 to 16.
+/// Returns OP_INVALIDOPCODE for other ints.
 BTCOpcode BTCOpcodeForSmallInteger(NSInteger smallInteger);
 
-// Converts opcode OP_<N> or OP_1NEGATE to an integer value.
-// If incorrect opcode is given, NSIntegerMax is returned.
+/// Converts opcode OP_<N> or OP_1NEGATE to an integer value.
+/// If incorrect opcode is given, NSIntegerMax is returned.
 NSInteger BTCSmallIntegerFromOpcode(BTCOpcode opcode);
 
 

--- a/CoreBitcoin/BTCSignatureHashType.h
+++ b/CoreBitcoin/BTCSignatureHashType.h
@@ -1,21 +1,25 @@
-// CoreBitcoin by Oleg Andreev <oleganza@gmail.com>, WTFPL.
+/// CoreBitcoin by Oleg Andreev <oleganza@gmail.com>, WTFPL.
 
 #ifndef CoreBitcoin_BTCSignatureHashType_h
 #define CoreBitcoin_BTCSignatureHashType_h
 
-// Hash type determines how OP_CHECKSIG hashes the transaction to create or
-// verify the signature in a transaction input.
-// Depending on hash type, transaction is modified in some way before its hash is computed.
-// Hash type is 1 byte appended to a signature in a transaction input.
+/**
+ * Hash type determines how OP_CHECKSIG hashes the transaction to create or
+ * verify the signature in a transaction input.
+ * Depending on hash type, transaction is modified in some way before its hash is computed.
+ * Hash type is 1 byte appended to a signature in a transaction input.
+ */
 typedef NS_ENUM(unsigned char, BTCSignatureHashType)
 {
-    // First three types are mutually exclusive (tested using "type & 0x1F").
-    
-    // Default. Signs all inputs and outputs.
-    // Other inputs have scripts and sequences zeroed out, current input has its script
-    // replaced by the previous transaction's output script (or, in case of P2SH,
-    // by the signatures and the redemption script).
-    // If (type & 0x1F) is not NONE or SINGLE, then this type is used.
+    /**
+     * First three types are mutually exclusive (tested using "type & 0x1F").
+     *
+     * Default. Signs all inputs and outputs.
+     * Other inputs have scripts and sequences zeroed out, current input has its script
+     * replaced by the previous transaction's output script (or, in case of P2SH,
+     * by the signatures and the redemption script).
+     * If (type & 0x1F) is not NONE or SINGLE, then this type is used.
+     */
     SIGHASH_ALL          = 1,
     BTCSignatureHashTypeAll = SIGHASH_ALL,
     
@@ -23,17 +27,25 @@ typedef NS_ENUM(unsigned char, BTCSignatureHashType)
     // Note: this is not safe when used with ANYONECANPAY, because then anyone who relays the transaction
     // can pick your input and use in his own transaction.
     // It's also not safe if all inputs are SIGHASH_NONE as well (or it's the only input).
+    /**
+     * All outputs are removed. "I don't care where it goes as long as others pay".
+     * Note: this is not safe when used with ANYONECANPAY, because then anyone who relays the transaction
+     * can pick your input and use in his own transaction.
+     * It's also not safe if all inputs are SIGHASH_NONE as well (or it's the only input).
+     */
     SIGHASH_NONE         = 2,
     BTCSignatureHashTypeNone = SIGHASH_NONE,
     
-    // Hash only the output with the same index as the current input.
-    // Preceding outputs are "nullified", other outputs are removed.
-    // Special case: if there is no matching output, hash is "0000000000000000000000000000000000000000000000000000000000000001" (32 bytes)
+    /**
+     * Hash only the output with the same index as the current input.
+     * Preceding outputs are "nullified", other outputs are removed.
+     * Special case: if there is no matching output, hash is "0000000000000000000000000000000000000000000000000000000000000001" (32 bytes)
+     */
     SIGHASH_SINGLE       = 3,
     BTCSignatureHashTypeSingle = SIGHASH_SINGLE,
     
-    // This mask is used to determine one of the first types independently from ANYONECANPAY option:
-    // E.g. if (type & SIGHASH_OUTPUT_MASK == SIGHASH_NONE) { blank all outputs }
+    /// This mask is used to determine one of the first types independently from ANYONECANPAY option:
+    /// E.g. if (type & SIGHASH_OUTPUT_MASK == SIGHASH_NONE) { blank all outputs }
     SIGHASH_OUTPUT_MASK  = 0x1F,
     BTCSignatureHashTypeOutputMask = SIGHASH_OUTPUT_MASK,
     
@@ -42,6 +54,13 @@ typedef NS_ENUM(unsigned char, BTCSignatureHashType)
     // E.g. a crowdfunding transaction with 100 BTC output can be signed independently by any number of people
     // and will become valid only when someone combines all inputs in a single transaction to make it valid.
     // Can be used together with any of the above types.
+    /**
+     * Removes all inputs except for current txin before hashing.
+     * This allows to sign the transaction outputs without knowing who and how adds other inputs.
+     * E.g. a crowdfunding transaction with 100 BTC output can be signed independently by any number of people
+     * and will become valid only when someone combines all inputs in a single transaction to make it valid.
+     * Can be used together with any of the above types.
+     */
     SIGHASH_ANYONECANPAY = 0x80,
     BTCSignatureHashTypeAnyoneCanPay = SIGHASH_ANYONECANPAY,
 };


### PR DESCRIPTION
If these doc changes look acceptable I'll work on converting the rest of the headers over.