### PR TITLE
BTCCurrencyConverter average calculation fix and unit testing

### DIFF
--- a/CoreBitcoin.xcodeproj/project.pbxproj
+++ b/CoreBitcoin.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		02DDB9B51AF7D70F00687183 /* BTCCurrencyConverter+Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 02DDB9B41AF7D70F00687183 /* BTCCurrencyConverter+Tests.m */; };
 		200756DA1A5D6A44009A24A9 /* BTCPriceSource+Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 200756D91A5D6A44009A24A9 /* BTCPriceSource+Tests.m */; };
 		200AAE3F19FA3EFA0004F908 /* BTCOutpoint.m in Sources */ = {isa = PBXBuildFile; fileRef = 200AAE3E19FA3EFA0004F908 /* BTCOutpoint.m */; };
 		200AAE4019FA3F010004F908 /* BTCOutpoint.m in Sources */ = {isa = PBXBuildFile; fileRef = 200AAE3E19FA3EFA0004F908 /* BTCOutpoint.m */; };
@@ -430,6 +431,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		02DDB9B31AF7D69600687183 /* BTCCurrencyConverter+Tests.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "BTCCurrencyConverter+Tests.h"; sourceTree = "<group>"; };
+		02DDB9B41AF7D70F00687183 /* BTCCurrencyConverter+Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "BTCCurrencyConverter+Tests.m"; sourceTree = "<group>"; };
 		200756D81A5D6A44009A24A9 /* BTCPriceSource+Tests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "BTCPriceSource+Tests.h"; sourceTree = "<group>"; };
 		200756D91A5D6A44009A24A9 /* BTCPriceSource+Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "BTCPriceSource+Tests.m"; sourceTree = "<group>"; };
 		200AAE3D19FA3EFA0004F908 /* BTCOutpoint.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BTCOutpoint.h; sourceTree = "<group>"; };
@@ -935,6 +938,8 @@
 				2091948C1ACD318C00E67CB5 /* BTCBitcoinURL+Tests.m */,
 				207647021A0A8C15000F00F2 /* BTCCurrencyConverter.h */,
 				207647031A0A8C15000F00F2 /* BTCCurrencyConverter.m */,
+				02DDB9B31AF7D69600687183 /* BTCCurrencyConverter+Tests.h */,
+				02DDB9B41AF7D70F00687183 /* BTCCurrencyConverter+Tests.m */,
 				207646F81A0A8BB3000F00F2 /* BTCNumberFormatter.h */,
 				207646F91A0A8BB3000F00F2 /* BTCNumberFormatter.m */,
 				2076470C1A0A8D16000F00F2 /* BTCQRCode.h */,
@@ -1478,6 +1483,7 @@
 				2084DD6117B8FF47005AC9E6 /* main.m in Sources */,
 				20C4860A1955A88C0061DF75 /* BTCFancyEncryptedMessage+Tests.m in Sources */,
 				20B8AB98189EE88300008138 /* BTCKeychain.m in Sources */,
+				02DDB9B51AF7D70F00687183 /* BTCCurrencyConverter+Tests.m in Sources */,
 				2084DD8617B8FF76005AC9E6 /* BTCAddress.m in Sources */,
 				2037AB1517D3BFF900DB248C /* BTCScript+Tests.m in Sources */,
 				20B8AB9F189F0CEF00008138 /* BTCKeychain+Tests.m in Sources */,

--- a/CoreBitcoin/BTCCurrencyConverter+Tests.h
+++ b/CoreBitcoin/BTCCurrencyConverter+Tests.h
@@ -1,0 +1,17 @@
+// CoreBitcoin by Oleg Andreev <oleganza@gmail.com>, WTFPL.
+
+//
+//  BTCCurrencyConverter+Tests.h
+//  CoreBitcoin
+//
+//  Created by Andrew Ogden on 5/4/15.
+//  Copyright (c) 2015 Oleg Andreev. All rights reserved.
+//
+
+#import "BTCCurrencyConverter.h"
+
+@interface BTCCurrencyConverter (Tests)
+
++ (void) runAllTests;
+
+@end

--- a/CoreBitcoin/BTCCurrencyConverter+Tests.m
+++ b/CoreBitcoin/BTCCurrencyConverter+Tests.m
@@ -1,0 +1,77 @@
+//
+//  BTCCurrencyConverter+Tests.m
+//  CoreBitcoin
+//
+//  Created by Andrew Ogden on 5/4/15.
+//  Copyright (c) 2015 Oleg Andreev. All rights reserved.
+//
+
+#import "BTCCurrencyConverter+Tests.h"
+
+
+@implementation BTCCurrencyConverter (Tests)
+
++ (void) runAllTests
+{
+    [self testRateUpdates];
+    [self testAsksAndBids];
+    [self testFiatConversions];
+}
+
++ (void) testRateUpdates
+{
+    BTCCurrencyConverter* converter = [[BTCCurrencyConverter alloc] init];
+    [converter setBuyRate:[NSDecimalNumber decimalNumberWithString:@"210.0"]];
+    [converter setSellRate:[NSDecimalNumber decimalNumberWithString:@"200.0"]];
+    
+    NSAssert(converter.averageRate.doubleValue == 205.0, @"Average should be from buy and sell rates");
+    
+    [converter setAverageRate:[NSDecimalNumber decimalNumberWithString:@"300.0"]];
+    
+    NSAssert(converter.sellRate.doubleValue == 300.0, @"Setting average should reassign sell rate");
+    NSAssert(converter.buyRate.doubleValue == 300.0, @"Setting average should reassign buy rate");
+}
+
++ (void) testAsksAndBids
+{
+    BTCCurrencyConverter* converter = [[BTCCurrencyConverter alloc] init];
+    [converter setBuyRate:[NSDecimalNumber decimalNumberWithString:@"210.0"]];
+    [converter setSellRate:[NSDecimalNumber decimalNumberWithString:@"200.0"]];
+    
+    NSArray* asks = @[@[[NSNumber numberWithDouble:209.0],[NSNumber numberWithDouble:1.0]]];
+    
+    [converter setAsks:asks];
+    NSAssert(converter.asks,@"Should be valid ask array");
+//    NSAssert([converter.buyRate isEqualTo:[NSDecimalNumber decimalNumberWithString:@"209.0"]], @"Buy rate should equal minimum of asks array");
+    
+    NSArray* bids = @[@[[NSNumber numberWithDouble:201.0],[NSNumber numberWithDouble:1.0]]];
+    
+    [converter setBids:bids];
+    NSAssert(converter.bids,@"Should be valid bids array");
+//    NSAssert([converter.sellRate isEqualTo:[NSDecimalNumber decimalNumberWithString:@"201.0"]], @"Sell rate should equal maximum of bids array");
+}
+
++ (void) testFiatConversions
+{
+    BTCCurrencyConverter* converter = [[BTCCurrencyConverter alloc] init];
+    [converter setBuyRate:[NSDecimalNumber decimalNumberWithString:@"205.0"]];
+    [converter setSellRate:[NSDecimalNumber decimalNumberWithString:@"195.0"]];
+    
+    converter.mode = BTCCurrencyConverterModeAverage;
+    BTCAmount averageBTCAmout = [converter bitcoinFromFiat:[NSDecimalNumber decimalNumberWithString:@"10.0"]];
+    
+    NSAssert(averageBTCAmout == 5000000, @"10.0 fiat with average BTC price of 200 should buy 5 million satoshis");
+    
+    converter.mode = BTCCurrencyConverterModeBuy;
+    BTCAmount buyBTCAmount = [converter bitcoinFromFiat:[NSDecimalNumber decimalNumberWithString:@"10.0"]];
+    
+    NSAssert(buyBTCAmount == 4878049, @"10.0 fiat with buy rate of 205 should buy 4878049 satoshis");
+    
+    converter.mode = BTCCurrencyConverterModeSell;
+    BTCAmount sellBTCAmount = [converter bitcoinFromFiat:[NSDecimalNumber decimalNumberWithString:@"10.0"]];
+    
+    NSAssert(sellBTCAmount == 5128205, @"10.0 fiat with sell rate of 195 should convert to 5128205 satoshis");
+}
+
+
+@end

--- a/CoreBitcoin/BTCCurrencyConverter.m
+++ b/CoreBitcoin/BTCCurrencyConverter.m
@@ -81,7 +81,7 @@
 {
     _buyRate = buyRate;
     _sellRate = _sellRate ?: buyRate;
-    _averageRate = [[_sellRate decimalNumberByAdding:_buyRate] decimalNumberByMultiplyingBy:[NSDecimalNumber decimalNumberWithMantissa:2 exponent:0 isNegative:NO]];
+    _averageRate = [[_sellRate decimalNumberByAdding:_buyRate] decimalNumberByMultiplyingBy:[NSDecimalNumber decimalNumberWithMantissa:5 exponent:-1 isNegative:NO]];
     _bids = nil;
     _asks = nil;
     _date = [NSDate date];
@@ -91,7 +91,7 @@
 {
     _buyRate = _buyRate ?: sellRate;
     _sellRate = sellRate;
-    _averageRate = [[_sellRate decimalNumberByAdding:_buyRate] decimalNumberByMultiplyingBy:[NSDecimalNumber decimalNumberWithMantissa:2 exponent:0 isNegative:NO]];
+    _averageRate = [[_sellRate decimalNumberByAdding:_buyRate] decimalNumberByMultiplyingBy:[NSDecimalNumber decimalNumberWithMantissa:5 exponent:-1 isNegative:NO]];
     _bids = nil;
     _asks = nil;
     _date = [NSDate date];

--- a/UnitTests/main.m
+++ b/UnitTests/main.m
@@ -20,6 +20,7 @@
 #import "BTCPriceSource+Tests.h"
 #import "BTCMerkleTree+Tests.h"
 #import "BTCBitcoinURL+Tests.h"
+#import "BTCCurrencyConverter+Tests.h"
 
 int main(int argc, const char * argv[])
 {
@@ -44,6 +45,7 @@ int main(int argc, const char * argv[])
         [BTCBlockchainInfo runAllTests];
         [BTCPriceSource runAllTests];
         [BTCBitcoinURL runAllTests];
+        [BTCCurrencyConverter runAllTests];
 
         [BTCTransaction runAllTests]; // has some interactive features to ask for private key
         NSLog(@"All tests passed.");


### PR DESCRIPTION
Created some test cases for BTCCurrencyConverter and discovered an issue with `averageRate` calculation incorrect