### PR TITLE
Fail fast in build scripts

### DIFF
--- a/build_libraries.sh
+++ b/build_libraries.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -e
 
 # Cleanup to start with a blank slate
 

--- a/update_openssl.sh
+++ b/update_openssl.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 # based on:
 # https://gist.github.com/tmiz/1441111


### PR DESCRIPTION
Use `set -e` in build scripts, so that if any steps fail it is reported to the developer and not silently ignored.