### PR TITLE
Enable camera selection (back or front) on BTCQRCode

### DIFF
--- a/CoreBitcoin/BTCQRCode.h
+++ b/CoreBitcoin/BTCQRCode.h
@@ -3,6 +3,7 @@
 #import <Foundation/Foundation.h>
 #if TARGET_OS_IPHONE
 #import <UIKit/UIKit.h>
+#import <AVFoundation/AVFoundation.h>
 #endif
 
 @interface BTCQRCode : NSObject
@@ -29,6 +30,18 @@
  */
 + (UIView*) scannerViewWithBlock:(void(^)(NSString* message))detectionBlock;
 
+
+/*!
+ * Returns a scanning view and retains a detection block.
+ *
+ * Block is called for every QR code detected. To stop recognition, remove view from the window.
+ *
+ * Block is released when view is removed from window.
+ *
+ * The device position helps selecting the camera (front or back)
+ */
++ (UIView*) scannerViewUsingDevice:(AVCaptureDevicePosition) devicePosition
+                         WithBlock:(void(^)(NSString* message))detectionBlock;
 #endif
 
 @end

--- a/CoreBitcoin/BTCQRCode.h
+++ b/CoreBitcoin/BTCQRCode.h
@@ -41,8 +41,8 @@
  * The device position helps selecting the camera (front or back)
  */
 + (UIView*) scannerViewUsingDevice:(AVCaptureDevicePosition) devicePosition
-                    andOrientation:(AVCaptureVideoOrientation) orientation
-                         WithBlock:(void(^)(NSString* message))detectionBlock;
+                       orientation:(AVCaptureVideoOrientation) orientation
+                             block:(void(^)(NSString* message))detectionBlock;
 #endif
 
 @end

--- a/CoreBitcoin/BTCQRCode.h
+++ b/CoreBitcoin/BTCQRCode.h
@@ -41,6 +41,7 @@
  * The device position helps selecting the camera (front or back)
  */
 + (UIView*) scannerViewUsingDevice:(AVCaptureDevicePosition) devicePosition
+                    andOrientation:(AVCaptureVideoOrientation) orientation
                          WithBlock:(void(^)(NSString* message))detectionBlock;
 #endif
 

--- a/CoreBitcoin/BTCQRCode.m
+++ b/CoreBitcoin/BTCQRCode.m
@@ -48,8 +48,8 @@
 }
 
 + (UIView*) scannerViewUsingDevice:(AVCaptureDevicePosition) devicePosition
-                    andOrientation:(AVCaptureVideoOrientation) orientation
-                         WithBlock:(void(^)(NSString* message))detectionBlock {
+                       orientation:(AVCaptureVideoOrientation) orientation
+                             block:(void(^)(NSString* message))detectionBlock {
     BTCQRCodeScannerView *view = [[BTCQRCodeScannerView alloc] initWithDetectionBlock:detectionBlock];
     view.cameraPosition = devicePosition;
     view.cameraOrientation = orientation;
@@ -58,8 +58,8 @@
 
 + (UIView*) scannerViewWithBlock:(void(^)(NSString* message))detectionBlock {
     return [self scannerViewUsingDevice:AVCaptureDevicePositionUnspecified
-                         andOrientation:0
-                              WithBlock:detectionBlock];
+                            orientation:0
+                                  block:detectionBlock];
 }
 
 #endif


### PR DESCRIPTION
I came across the need to select the camera for the QR Code scanner so did a slight modification of **BTCQRCode**.

I hope you find it useful and if I need to follow some code convention just let me know. 

