### PR TITLE
Fixes error on change script missing

### DIFF
--- a/CoreBitcoin/BTCTransactionBuilder.m
+++ b/CoreBitcoin/BTCTransactionBuilder.m
@@ -32,7 +32,7 @@ NSString* const BTCTransactionBuilderErrorDomain = @"com.oleganza.CoreBitcoin.Tr
 
 - (BTCTransactionBuilderResult*) buildTransaction:(NSError**)errorOut {
     if (!self.changeScript) {
-        if (errorOut) *errorOut = [NSError errorWithDomain:BTCTransactionBuilderErrorDomain code:BTCTransactionBuilderInsufficientFunds userInfo:nil];
+        if (errorOut) *errorOut = [NSError errorWithDomain:BTCTransactionBuilderErrorDomain code:BTCTransactionBuilderChangeAddressMissing userInfo:nil];
         return nil;
     }
 


### PR DESCRIPTION
The incorrect error code was sent when the change address/script wasn't set.