### PR TITLE
Minor warning fix, and improvement to transaction signing API

### DIFF
--- a/CoreBitcoin/BTCBase58.m
+++ b/CoreBitcoin/BTCBase58.m
@@ -27,7 +27,7 @@ NSMutableData* BTCDataFromBase58CString(const char* cstring) {
     __block BIGNUM bn;     BN_init(&bn);     BN_zero(&bn);
     __block BIGNUM bnChar; BN_init(&bnChar);
     
-    void(^finish)() = ^{
+    void(^finish)(void) = ^{
         if (pctx) BN_CTX_free(pctx);
         BN_clear_free(&bn58);
         BN_clear_free(&bn);
@@ -134,7 +134,7 @@ char* BTCBase58CStringWithData(NSData* data) {
     __block BIGNUM dv; BN_init(&dv); BN_zero(&dv);
     __block BIGNUM rem; BN_init(&rem); BN_zero(&rem);
     
-    void(^finish)() = ^{
+    void(^finish)(void) = ^{
         if (pctx) BN_CTX_free(pctx);
         BN_clear_free(&bn58);
         BN_clear_free(&bn0);

--- a/CoreBitcoin/BTCTransaction.h
+++ b/CoreBitcoin/BTCTransaction.h
@@ -11,6 +11,7 @@ static const BTCAmount BTCTransactionDefaultFeeRate = 10000; // 10K satoshis per
 @class BTCScript;
 @class BTCTransactionInput;
 @class BTCTransactionOutput;
+@class BTCKey;
 
 /*!
  * Converts string transaction ID (reversed tx hash in hex format) to transaction hash.
@@ -127,6 +128,9 @@ NSString* BTCTransactionIDFromHash(NSData* txhash) DEPRECATED_ATTRIBUTE;
 // Hash for signing a transaction.
 // You should supply the output script of the previous transaction, desired hash type and input index in this transaction.
 - (NSData*) signatureHashForScript:(BTCScript*)subscript inputIndex:(uint32_t)inputIndex hashType:(BTCSignatureHashType)hashType error:(NSError**)errorOut;
+
+// Attempts to sign the index at position i with key, returns failure / success
+- (BOOL)attemptToSignInputAtIndex:(uint32_t)i withKey:(BTCKey *)key error:(NSError **)errorOut;
 
 // Adds input script
 - (void) addInput:(BTCTransactionInput*)input;


### PR DESCRIPTION
Found it necessary to sign a transaction that wasn't generated using the builder.  Moved the transaction input signing functionality into BTCTransaction and exposed it there.

Tested:
Downloaded an unsigned transaction from coinb.in -- Signed it with my own private key -- Verified transaction was now signed correctly.