### PR TITLE
Use CFSwapInt32LittleToHost to convert arg of uint32_t

### DIFF
--- a/CoreBitcoin/BTCScript.m
+++ b/CoreBitcoin/BTCScript.m
@@ -1119,7 +1119,7 @@
             if (offset + sizeof(dataLength) > length) return nil;
             
             memcpy(&dataLength, bytes + offset + sizeof(opcode), sizeof(dataLength));
-            dataLength = CFSwapInt16LittleToHost(dataLength);
+            dataLength = CFSwapInt32LittleToHost(dataLength);
             
             NSUInteger chunkLength = sizeof(opcode) + sizeof(dataLength) + dataLength;
             


### PR DESCRIPTION
When parse chunk of `OP_PUSHDATA4`, should use CFSwapInt32LittleToHost to convert the argument of uint32_t.