### PR TITLE
MacOS build to use Foundation for pch

### DIFF
--- a/CoreBitcoinOSX/CoreBitcoinOSX-Prefix.pch
+++ b/CoreBitcoinOSX/CoreBitcoinOSX-Prefix.pch
@@ -5,5 +5,5 @@
 //
 
 #ifdef __OBJC__
-    #import <Cocoa/Cocoa.h>
+    #import <Foundation/Foundation.h>
 #endif


### PR DESCRIPTION

After this change, I believe there is no remaining difference between the sources for MacOS vs iOS.
The MacOS lib does not need the entire Cocoa header to compile, and so this may somewhat improve build times.
Reviewers @oleganza