### PR TITLE
Speed up BTCHexFromData by 5.5x (-85%)

### DIFF
--- a/CoreBitcoin/BTCData.m
+++ b/CoreBitcoin/BTCData.m
@@ -183,14 +183,14 @@ NSData* BTCDataWithHexCString(const char* hexCString) {
     return [[NSData alloc] initWithBytesNoCopy:buf length:len/2];
 }
 
-static char hexValues[16] = {
+static const char hexValues[16] = {
     '0', '1', '2', '3',
     '4', '5', '6', '7',
     '8', '9', 'a', 'b',
     'c', 'd', 'e', 'f',
 };
 
-static char upperHexValues[16] = {
+static const char upperHexValues[16] = {
     '0', '1', '2', '3',
     '4', '5', '6', '7',
     '8', '9', 'A', 'B',

--- a/CoreBitcoin/BTCData.m
+++ b/CoreBitcoin/BTCData.m
@@ -210,7 +210,7 @@ static NSString* BTCHexFromDataWithCharset(NSData* data, const char* charset) {
     return [[NSString alloc]
         initWithBytesNoCopy:outString
         length:length
-        encoding:NSUTF8StringEncoding
+        encoding:NSASCIIStringEncoding
         freeWhenDone:YES
     ];
 }

--- a/CoreBitcoin/BTCData.m
+++ b/CoreBitcoin/BTCData.m
@@ -204,8 +204,8 @@ static NSString* BTCHexFromDataWithCharset(NSData* data, const char* charset) {
     const unsigned char *bytes = data.bytes;
     for (uint32_t i = 0; i < inLength; i++) {
         unsigned char byte = bytes[i];
-        outString[i*2] = charset[(byte & 0xF0) >> 4];
-        outString[i*2+1] = charset[(byte & 0x0F)];
+        outString[i*2] = charset[byte >> 4];
+        outString[i*2+1] = charset[byte & 0x0F];
     }
     return [[NSString alloc]
         initWithBytesNoCopy:outString

--- a/CoreBitcoin/BTCData.m
+++ b/CoreBitcoin/BTCData.m
@@ -183,20 +183,36 @@ NSData* BTCDataWithHexCString(const char* hexCString) {
     return [[NSData alloc] initWithBytesNoCopy:buf length:len/2];
 }
 
+static char hexValues[16] = {
+    '0', '1', '2', '3',
+    '4', '5', '6', '7',
+    '8', '9', 'a', 'b',
+    'c', 'd', 'e', 'f',
+};
 
-NSString* BTCHexFromDataWithFormat(NSData* data, const char* format) {
-    if (!data) return nil;
-    
-    NSUInteger length = data.length;
-    if (length == 0) return @"";
-    
-    NSMutableData* resultdata = [NSMutableData dataWithLength:length * 2];
-    char *dest = resultdata.mutableBytes;
-    unsigned const char *src = data.bytes;
-    for (int i = 0; i < length; ++i) {
-        sprintf(dest + i*2, format, (unsigned int)(src[i]));
+static char upperHexValues[16] = {
+    '0', '1', '2', '3',
+    '4', '5', '6', '7',
+    '8', '9', 'A', 'B',
+    'C', 'D', 'E', 'F',
+};
+
+static NSString* BTCHexFromDataWithCharset(NSData* data, const char* charset) {
+    size_t inLength = data.length;
+    size_t length = inLength * 2;
+    uint8_t *outString = malloc(length);
+    const unsigned char *bytes = data.bytes;
+    for (uint32_t i = 0; i < inLength; i++) {
+        unsigned char byte = bytes[i];
+        outString[i*2] = charset[(byte & 0xF0) >> 4];
+        outString[i*2+1] = charset[(byte & 0x0F)];
     }
-    return [[NSString alloc] initWithData:resultdata encoding:NSASCIIStringEncoding];
+    return [[NSString alloc]
+        initWithBytesNoCopy:outString
+        length:length
+        encoding:NSUTF8StringEncoding
+        freeWhenDone:YES
+    ];
 }
 
 NSString* BTCHexStringFromData(NSData* data) { // deprecated
@@ -208,11 +224,11 @@ NSString* BTCUppercaseHexStringFromData(NSData* data) { // deprecated
 }
 
 NSString* BTCHexFromData(NSData* data) {
-    return BTCHexFromDataWithFormat(data, "%02x");
+    return BTCHexFromDataWithCharset(data, hexValues);
 }
 
 NSString* BTCUppercaseHexFromData(NSData* data) {
-    return BTCHexFromDataWithFormat(data, "%02X");
+    return BTCHexFromDataWithCharset(data, upperHexValues);
 }
 
 


### PR DESCRIPTION
I wrote an optimized version of `BTCHexFromData`. The speedup with `-O3` is approximately 85% (or 5.5x) compared to the current implementation.

The speedup comes from specialized printing and reduced memory allocation.

Here is the program I used to time the change:

```
@import Foundation;
#import <mach/mach_time.h>

static char hexValues[16] = {
    '0',
    '1',
    '2',
    '3',
    '4',
    '5',
    '6',
    '7',
    '8',
    '9',
    'a',
    'b',
    'c',
    'd',
    'e',
    'f',
};

NSString *toHex(NSData *data) {
    size_t inLength = data.length;
    size_t length = inLength * 2;
    uint8_t *outString = malloc(length);
    const unsigned char *bytes = data.bytes;
    for (uint32_t i = 0; i < inLength; i++) {
        unsigned char byte = bytes[i];
        outString[i*2] = hexValues[(byte & 0xF0) >> 4];
        outString[i*2+1] = hexValues[(byte & 0x0F)];
    }
    return [[NSString alloc]
        initWithBytesNoCopy:outString
        length:length
        encoding:NSUTF8StringEncoding
        freeWhenDone:YES
    ];
}

NSString* BTCHexFromDataWithFormat(NSData* data, const char* format) {
    if (!data) return nil;
    
    NSUInteger length = data.length;
    if (length == 0) return @"";
    
    NSMutableData* resultdata = [NSMutableData dataWithLength:length * 2];
    char *dest = resultdata.mutableBytes;
    unsigned const char *src = data.bytes;
    for (int i = 0; i < length; ++i) {
        sprintf(dest + i*2, format, (unsigned int)(src[i]));
    }
    return [[NSString alloc] initWithData:resultdata encoding:NSASCIIStringEncoding];
}

NSString* BTCHexFromData(NSData* data) {
    return BTCHexFromDataWithFormat(data, "%02x");
}


NSMutableArray<NSData *> *testVector;
void initVector() {
    testVector = [NSMutableArray array];
    for (int i = 0; i < 400000; i++) {
        void *buf = malloc(32);
        arc4random_buf(buf, 32);
        [testVector
            addObject:[NSData
                dataWithBytesNoCopy:buf
                length:32
                freeWhenDone:YES
            ]
        ];
    }
}
NSMutableArray<NSString *> *outVector;
void timeMethod(NSString *(method)(NSData *)) {
    outVector = [NSMutableArray array];
    for (NSData *data in testVector) {
        [outVector addObject:method(data)];
    }
}

int main() {
    @autoreleasepool {
        uint64_t start = mach_absolute_time();
        initVector();
        uint64_t setup = mach_absolute_time();
        timeMethod(BTCHexFromData);
        uint64_t btcHex = mach_absolute_time();
        timeMethod(toHex);
        uint64_t hex = mach_absolute_time();
        NSLog(@"setup : %llu", setup - start);
        NSLog(@"btcHex: %llu", btcHex - setup);
        NSLog(@"Hex   : %llu", hex - btcHex);
        return 0;
    }
}
```

Here is the output:
```
will@Williams-MacBook-Pro.local:~/projects/CoreBitcoin(master)*$ clang -fmodules timer.m 
will@Williams-MacBook-Pro.local:~/projects/CoreBitcoin(master)*$ ./a.out 
2018-07-13 18:53:14.825 a.out[71380:1588521] setup : 174539326
2018-07-13 18:53:14.826 a.out[71380:1588521] btcHex: 1138551621
2018-07-13 18:53:14.826 a.out[71380:1588521] Hex   : 217758575
will@Williams-MacBook-Pro.local:~/projects/CoreBitcoin(master)*$ clang -fmodules -O3 timer.m
will@Williams-MacBook-Pro.local:~/projects/CoreBitcoin(master)*$ ./a.out 
2018-07-13 18:53:58.248 a.out[71425:1589886] setup : 172171645
2018-07-13 18:53:58.248 a.out[71425:1589886] btcHex: 1148045936
2018-07-13 18:53:58.248 a.out[71425:1589886] Hex   : 172938196
```

Reviewer @oleganza 