### PR TITLE
docs: fix simple typo, cerialized -> serialized

### DIFF
--- a/CoreBitcoin/BTCPaymentMethodRequest.h
+++ b/CoreBitcoin/BTCPaymentMethodRequest.h
@@ -37,7 +37,7 @@ extern NSInteger const BTCPaymentMethodRequestVersion1;
 
 // Array of DER encoded certificates or nil if pkiType does offer certificates.
 // This list is extracted from raw `pkiData`.
-// If set, certificates are cerialized in X509Certificates object and set to pkiData.
+// If set, certificates are serialized in X509Certificates object and set to pkiData.
 @property(nonatomic, readonly, nonnull) NSArray* certificates;
 
 // A date against which the payment request is being validated.

--- a/CoreBitcoin/BTCPaymentRequest.h
+++ b/CoreBitcoin/BTCPaymentRequest.h
@@ -97,7 +97,7 @@ BOOL BTCPaymentRequestVerifySignature(NSString* __nullable pkiType,
 
 // Array of DER encoded certificates or nil if pkiType does offer certificates.
 // This list is extracted from raw `pkiData`.
-// If set, certificates are cerialized in X509Certificates object and set to pkiData.
+// If set, certificates are serialized in X509Certificates object and set to pkiData.
 @property(nonatomic, readonly, nonnull) NSArray* certificates;
 
 // A date against which the payment request is being validated.


### PR DESCRIPTION
There is a small typo in CoreBitcoin/BTCPaymentMethodRequest.h, CoreBitcoin/BTCPaymentRequest.h.

Should read `serialized` rather than `cerialized`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md